### PR TITLE
Week3. Use Module

### DIFF
--- a/3.module/main.tf
+++ b/3.module/main.tf
@@ -1,0 +1,83 @@
+# main.tf
+
+# 모듈 호출 - VPC
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"  # VPC 모듈
+  version = "5.13.0" 
+
+  name = "my-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = var.azs
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24"]
+  public_subnets  = ["10.0.3.0/24", "10.0.4.0/24"]
+
+  enable_nat_gateway = true
+}
+
+# 모듈 호출 - Security Group
+module "security_group" {
+  source = "terraform-aws-modules/security-group/aws"  # Security Group 모듈
+  version = "5.0.0"
+
+  name        = "my-security-group"
+  description = "Allow SSH and HTTP"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_with_cidr_blocks = [
+      {
+        from_port   = 443                                #인바운드 시작 포트
+        to_port     = 443                                #인바운드 끝나는 포트
+        protocol    = "tcp"                              #사용할 프로토콜
+        description = "https"                            #설명
+        cidr_blocks = "0.0.0.0/0"                        #허용할 IP 범위
+      },
+      {
+        from_port   = 80
+        to_port     = 80
+        protocol    = "tcp"
+        description = "http"
+        cidr_blocks = "0.0.0.0/0"
+      },
+      {
+        from_port   = 22
+        to_port     = 22
+        protocol    = "tcp"
+        description = "ssh"
+        cidr_blocks = "0.0.0.0/0"
+      }
+  ]
+    egress_with_cidr_blocks = [
+      {
+        from_port   = 0                                #아웃바운드 시작 포트
+        to_port     = 0                                #아웃바운드 끝나는 포트
+        protocol    = "-1"                             #사용할 프로토콜
+        description = "all"                            #설명
+        cidr_blocks = "0.0.0.0/0"                      #허용할 IP 범위
+      }
+  ]
+}
+
+# EC2 인스턴스 생성
+resource "aws_instance" "my_ec2_instance" {
+  ami           = var.ami_id
+  instance_type = var.instance_type
+
+  subnet_id              = module.vpc.public_subnets[0]
+  vpc_security_group_ids = [module.security_group.security_group_id]
+
+  tags = {
+    Name = "MyEC2Instance"
+  }
+
+  associate_public_ip_address = true
+  
+  # user_data 스크립트를 사용하여 EC2내에서 Nginx 설치 및 시작
+  user_data = <<-EOF
+              #!/bin/bash
+              sudo apt-get update -y
+              sudo apt-get install nginx -y
+              sudo systemctl start nginx
+              sudo systemctl enable nginx
+              EOF
+} 

--- a/3.module/outputs.tf
+++ b/3.module/outputs.tf
@@ -1,0 +1,31 @@
+# outputs.tf
+
+# EC2 인스턴스 이름 출력
+output "ec2_instance_name" {
+  description = "The name of the EC2 instance"
+  value       = aws_instance.my_ec2_instance.tags["Name"]
+}
+
+# VPC ID 출력
+output "vpc_id" {
+  description = "The VPC ID"
+  value       = module.vpc.vpc_id
+}
+
+# Public Subnet ID 출력
+output "public_subnet_id" {
+  description = "The public subnet ID"
+  value       = module.vpc.public_subnets
+}
+
+# Private Subnet ID 출력
+output "private_subnet_id" {
+  description = "The private subnet ID"
+  value       = module.vpc.private_subnets
+}
+
+# Security Group ID 출력
+output "security_group_id" {
+  description = "The security group ID"
+  value       = module.security_group.security_group_id
+}

--- a/3.module/provider.tf
+++ b/3.module/provider.tf
@@ -1,0 +1,5 @@
+# provider.tf
+
+provider "aws" {
+  region = var.region  # 한국 리전 사용
+}

--- a/3.module/terraform.tfvars
+++ b/3.module/terraform.tfvars
@@ -1,0 +1,3 @@
+# terraform.tfvars
+
+ami_id = "ami-05d2438ca66594916" #ubuntu

--- a/3.module/variables.tf
+++ b/3.module/variables.tf
@@ -1,0 +1,24 @@
+# variables.tf
+
+variable "region" {
+  description = "The AWS region to deploy resources"
+  type        = string
+  default     = "ap-northeast-2"  # 서울 리전 코드
+}
+
+variable "azs" {
+  description = "The availability zones to use for the VPC"
+  type        = list(string)
+  default     = ["ap-northeast-2a", "ap-northeast-2b"]  # 서울 리전의 가용 영역
+}
+
+variable "ami_id" {
+  description = "The AMI ID to use for the EC2 instance"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "The EC2 instance type"
+  type        = string
+  default     = "t2.micro"
+}


### PR DESCRIPTION
## 개요

> module 사용해 vpc(subnet)와 security group 리소스 생성
> 생성한 vpc와 security group 사용해 ec2 instance 생성
> 생성한 ec2 instance 내에 NGINX 설치 및 실행 스크립트 실행 -> 결과 확인 목적
> Outputs으로 생성한 리소스 정보(ex.id, name) 출력

## main.tf

- module로 vpc 생성
  - cidr
  - private subnet, public subnet
  - nat gateway 설정
- module로 security group 생성
  - 직전에 생성한 vpc id와 연결 -> 해당 vpc로 접근하는 트래픽 관리 
  - 인바운드 규칙으로 HTTP, HTTPS, SSH 허용
  - 아웃바운드 규칙으로 모두 허용
- EC2 instance 생성
  - ami -> 변수 참조 (variables.tf)
  - instance type -> 변수 참조
  - subnet -> 직전에 생성한 vpc의 public subnet 참조
  - security group -> 직전에 생성한 security group 참조
  - Public IP 설정 -> 브라우저에서 정상적으로 생성되었는지 확인하기 위한 목적
  - user data 스크립트 ->  public IP로 브라우저에 접근하면 NGINX 웹페이지가 나타나도록 함

## outputs.tf

- instance 이름
- vpc id
- public subnet
- private subnet
- security group id

## provider.tf

- aws region 설정

## terraform.tfvars

- 생성할 EC2 instance ami 설정

## variables.tf

- region
- azs
- ami id
- instance type 

## terraform 명령어

```
terraform init
terraform plan
terraform apply
terraform destory
```

## 결과

- Public IP로 브라우저에서 접근하면 NGINX 페이지 나타남
- AWS console에 생성된 리소스와 Outputs에 나타난 정보 비교