### PR TITLE
Week4. GCP Compute Engine 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# gcp-credentials.json git ignore
+4.multi_cloud_gcp/*.json

--- a/4.multi_cloud_gcp/main.tf
+++ b/4.multi_cloud_gcp/main.tf
@@ -1,0 +1,25 @@
+// Configure the Google Cloud provider
+provider "google" {
+ credentials = "${file("gcp-credentials.json")}"
+ project     = "terraform-gcp-437815"
+ region      = "us-central1"
+}
+
+// Create a GCE instance
+resource "google_compute_instance" "default" {
+  name         = "terraform"
+  machine_type = "f1-micro"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+    }
+  }
+}


### PR DESCRIPTION
## 개요

> Terraform은 Multi Cloud 사용 시 유용
> Multi Cloud 사용하기 전에 GCP 먼저 사용

## 사전 GCP 작업 필요

- 사용할 **Project 생성**과 Project 내에서 접근할 수 있는 권한을 결정하는 Service Account 생성

## main.tf

|  AWS EC2에 해당하는 GCP Compute Engine 생성

- provider인 GCP와 연결되도록 설정
  - 이전에 생성한 service account json 파일로 credentials 설정 
  - project id와 region 설정
- GCE (Google Compute Engine) 설정
  - 인스턴스 이름: terraform
  - 인스턴스 타입: f1-micro
  - zone: us-central-a
  - OS image: ubuntu-2204-lts
  - 기본 네트워크인 default 사용

## terraform 명령어

```
terraform init
terraform plan
terraform apply
terraform destory
```

## 결과

- GCP Console에 GCE(Google Compute Engine) 생성 & 접속 가능