### PR TITLE
Week4. AWS EC2 & GCP Compute Engine 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 # gcp-credentials.json git ignore
-4.multi_cloud_gcp/*.json
+*.json

--- a/1.create_ec2/main.tf
+++ b/1.create_ec2/main.tf
@@ -1,12 +1,12 @@
 # main.tf
 
-terraform {
-	required_version = ">= 1.5.7"
-	
-	required_providers {
-		aws = {
-			source = "hashicorp/aws"
-			version = "~> 5.0" #틸드 연산자. 5.0.x 버전 설치
-		}
-	}
-}
+#terraform {
+#	required_version = ">= 1.5.7"
+#	
+#	required_providers {
+#		aws = {
+#			source = "hashicorp/aws"
+#			version = "~> 5.0" #틸드 연산자. 5.0.x 버전 설치
+#		}
+#	}
+#}

--- a/1.create_ec2/provider.tf
+++ b/1.create_ec2/provider.tf
@@ -1,5 +1,14 @@
 # provider.tf
 
+terraform {
+	required_providers {
+		aws = {
+			source = "hashicorp/aws"
+			version = "~> 5.0"
+		}
+	}
+}
+
 provider "aws" {
 	profile = "terraform_prof" #aws configure --profile에서 설정한 profile
 	region = "ap-northeast-2"

--- a/1.create_ec2/terraform.dev.tfvars
+++ b/1.create_ec2/terraform.dev.tfvars
@@ -1,0 +1,15 @@
+# terraform.dev.tfvars
+
+region = "ap-northeast-2"
+project_name = "terraform_project"
+target_label = "dev"
+
+
+### VPC variables
+vpc_cidr = "172.100.0.0/16"
+public_cidr = ["172.100.0.0/24"]
+azs = ["ap-northeast-2a"]
+
+
+### EC2 variables
+ec2_instance_spec = "t2.micro"

--- a/4.multi_cloud_awsgcp/ec2.tf
+++ b/4.multi_cloud_awsgcp/ec2.tf
@@ -1,0 +1,80 @@
+# 모듈 호출 - VPC
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"  # VPC 모듈
+  version = "5.13.0" 
+
+  name = "my-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = ["ap-northeast-2a", "ap-northeast-2b"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24"]
+  public_subnets  = ["10.0.3.0/24", "10.0.4.0/24"]
+
+  enable_nat_gateway = true
+}
+
+# 모듈 호출 - Security Group
+module "security_group" {
+  source = "terraform-aws-modules/security-group/aws"  # Security Group 모듈
+  version = "5.0.0"
+
+  name        = "my-security-group"
+  description = "Allow SSH and HTTP"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_with_cidr_blocks = [
+      {
+        from_port   = 443                                #인바운드 시작 포트
+        to_port     = 443                                #인바운드 끝나는 포트
+        protocol    = "tcp"                              #사용할 프로토콜
+        description = "https"                            #설명
+        cidr_blocks = "0.0.0.0/0"                        #허용할 IP 범위
+      },
+      {
+        from_port   = 80
+        to_port     = 80
+        protocol    = "tcp"
+        description = "http"
+        cidr_blocks = "0.0.0.0/0"
+      },
+      {
+        from_port   = 22
+        to_port     = 22
+        protocol    = "tcp"
+        description = "ssh"
+        cidr_blocks = "0.0.0.0/0"
+      }
+  ]
+    egress_with_cidr_blocks = [
+      {
+        from_port   = 0                                #아웃바운드 시작 포트
+        to_port     = 0                                #아웃바운드 끝나는 포트
+        protocol    = "-1"                             #사용할 프로토콜
+        description = "all"                            #설명
+        cidr_blocks = "0.0.0.0/0"                      #허용할 IP 범위
+      }
+  ]
+}
+
+resource "aws_instance" "aws_ec2_instance" {
+  ami = "ami-05d2438ca66594916" 
+  instance_type = "t2.micro"
+
+  subnet_id              = module.vpc.public_subnets[0]
+  vpc_security_group_ids = [module.security_group.security_group_id]
+
+  associate_public_ip_address = true
+
+  tags = {
+    Name = "multi-cloud-aws-instance"
+  }
+
+  # user_data 스크립트를 사용하여 EC2내에서 Nginx 설치 및 시작
+  user_data = <<-EOF
+              #!/bin/bash
+              sudo apt-get update -y
+              sudo apt-get install nginx -y
+              sudo systemctl start nginx
+              sudo systemctl enable nginx
+              EOF
+}

--- a/4.multi_cloud_awsgcp/gce.tf
+++ b/4.multi_cloud_awsgcp/gce.tf
@@ -1,0 +1,18 @@
+// Create a GCE instance
+resource "google_compute_instance" "gcp-gce-instance" {
+  name         = "multi-cloud-gce-instance"
+  machine_type = "f1-micro"
+  zone         = "southamerica-east1-c"
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+    }
+  }
+}

--- a/4.multi_cloud_awsgcp/provider.tf
+++ b/4.multi_cloud_awsgcp/provider.tf
@@ -1,0 +1,27 @@
+# provider.tf
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.70.0"   # AWS 최신 버전으로 설정
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.5.0"   # GCP 최신 버전으로 설정
+    }
+  }
+
+  required_version = ">= 1.9.5" # terraform 최신 버전
+}
+
+provider "aws" {
+  profile = "terraform_prof"
+  region = "ap-northeast-2"  # 한국 리전 사용
+}
+
+provider "google" {
+ credentials = "${file("../gcp-credentials.json")}"
+ project     = "terraform-gcp-437815"
+ region      = "southamerica-east1"
+}

--- a/4.multi_cloud_gcp/main.tf
+++ b/4.multi_cloud_gcp/main.tf
@@ -1,6 +1,6 @@
 // Configure the Google Cloud provider
 provider "google" {
- credentials = "${file("gcp-credentials.json")}"
+ credentials = "${file("../gcp-credentials.json")}"
  project     = "terraform-gcp-437815"
  region      = "us-central1"
 }


### PR DESCRIPTION
## 개요

> Terraform은 Multi Cloud 사용 시 유용
> Multi Cloud 사용해보기 위해 간단한 AWS EC2와 GCP GCE 생성

## 사전 GCP 작업 필요

- 사용할 **Project 생성**과 Project 내에서 접근할 수 있는 권한을 결정하는 Service Account 생성

## ec2.tf

|  AWS EC2 생성

## gce.tf

| GCP GCE 생성

## provider.tf

| AWS와 GCP provider 설정


## terraform 명령어

```
terraform init
terraform plan
terraform apply
terraform destory
```

## 결과

- AWS EC2 생성 및 GCP Console에 GCE(Google Compute Engine) 생성, 접속 가능