### PR TITLE
Week5. AWS EKS 생성

### DIFF
--- a/5.learn-terraform-provision-eks-cluster/main.tf
+++ b/5.learn-terraform-provision-eks-cluster/main.tf
@@ -1,0 +1,106 @@
+provider "aws" {
+  profile = "tf-seoyeon"
+  region = var.region
+}
+
+data "aws_availability_zones" "available" {
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+locals {
+  cluster_name = "education-eks-${random_string.suffix.result}"
+}
+
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.8.1"
+
+  name = "education-vpc"
+
+  cidr = "10.0.0.0/16"
+  azs  = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = 1
+  }
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "20.8.5"
+
+  cluster_name    = local.cluster_name
+  cluster_version = "1.30"
+
+  cluster_endpoint_public_access           = true
+  enable_cluster_creator_admin_permissions = true
+
+  cluster_addons = {
+    aws-ebs-csi-driver = {
+      service_account_role_arn = module.irsa-ebs-csi.iam_role_arn
+    }
+  }
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  eks_managed_node_group_defaults = {
+    ami_type = "AL2_x86_64"
+  }
+
+  eks_managed_node_groups = {
+    one = {
+      name = "node-group-1"
+
+      instance_types = ["t3.small"]
+
+      min_size     = 1
+      max_size     = 3
+      desired_size = 2
+    }
+
+    two = {
+      name = "node-group-2"
+
+      instance_types = ["t3.small"]
+
+      min_size     = 1
+      max_size     = 2
+      desired_size = 1
+    }
+  }
+}
+
+data "aws_iam_policy" "ebs_csi_policy" {
+  arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+
+module "irsa-ebs-csi" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "5.39.0"
+
+  create_role                   = true
+  role_name                     = "AmazonEKSTFEBSCSIRole-${module.eks.cluster_name}"
+  provider_url                  = module.eks.oidc_provider
+  role_policy_arns              = [data.aws_iam_policy.ebs_csi_policy.arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
+}

--- a/5.learn-terraform-provision-eks-cluster/outputs.tf
+++ b/5.learn-terraform-provision-eks-cluster/outputs.tf
@@ -1,0 +1,19 @@
+output "cluster_endpoint" {
+  description = "Endpoint for EKS control plane"
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_security_group_id" {
+  description = "Security group ids attached to the cluster control plane"
+  value       = module.eks.cluster_security_group_id
+}
+
+output "region" {
+  description = "AWS region"
+  value       = var.region
+}
+
+output "cluster_name" {
+  description = "Kubernetes Cluster Name"
+  value       = module.eks.cluster_name
+}

--- a/5.learn-terraform-provision-eks-cluster/terraform.tf
+++ b/5.learn-terraform-provision-eks-cluster/terraform.tf
@@ -1,0 +1,26 @@
+terraform {
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.47.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6.1"
+    }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0.5"
+    }
+
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "~> 2.3.4"
+    }
+  }
+
+  required_version = "~> 1.3"
+}

--- a/5.learn-terraform-provision-eks-cluster/variables.tf
+++ b/5.learn-terraform-provision-eks-cluster/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-2"
+}


### PR DESCRIPTION
## 개요

> Terraform 사용해 AWS EKS Cluster 구축

## 1. main.tf

- AWS EKS 생성 시 필요한 리소스 생성
- eks_managed_node_groups가 worker node이고 **worker node들은 private subnet에 생성**

## 2. variables.tf

- region을 ap-northeast-2로 설정

## 3. terraform.tf

- EKS 생성 시 필요한 provider 버전 설정

## 4. outputs.tf

- Output으로 출력할 변수 지정

## terraform 명령어

```
terraform init
terraform plan
terraform apply
terraform destroy
```

## 결과

AWS EKS Cluster 생성
터미널에서 아래 명령어 수행 시 EKS Cluster 접근 가능

```
aws eks --region ap-northeast-2 update-kubeconfig --name {EKS CLUSTER NAME} --profile {aws-profile}
```
