### PR TITLE
[Stock Project] Create EC2

### DIFF
--- a/stock_project/main.tf
+++ b/stock_project/main.tf
@@ -1,0 +1,70 @@
+# Security Group 생성
+resource "aws_security_group" "ec2_security_group" {
+  name        = "ec2-security-group"
+  description = "Allow SSH, HTTP, and HTTPS access from local IP"
+  vpc_id      = var.vpc_id
+
+  # Inbound rules (Allow access from local IP)
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] 
+    description = "Allow SSH from all IPs"
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # 모든 IP에서 HTTP 접근 허용
+    description = "Allow HTTP from all"
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # 모든 IP에서 HTTPS 접근 허용
+    description = "Allow HTTPS from all"
+  }
+
+  # Outbound rules (Allow all traffic)
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound traffic"
+  }
+
+  tags = {
+    Name = "EC2 Security Group"
+  }
+}
+
+
+
+# EC2 인스턴스 생성
+resource "aws_instance" "my_ec2_instance" {
+  ami           = var.ami_id
+  instance_type = var.instance_type
+
+  subnet_id              = var.public_subnet_id
+  vpc_security_group_ids = [aws_security_group.ec2_security_group.id]
+
+  tags = {
+    Name = "MyEC2Instance_for_RDS"
+  }
+
+  associate_public_ip_address = true
+  
+  # user_data 스크립트를 사용하여 EC2내에서 Nginx 설치 및 시작
+  user_data = <<-EOF
+              #!/bin/bash
+              sudo apt-get update -y
+              sudo apt-get install nginx -y
+              sudo systemctl start nginx
+              sudo systemctl enable nginx
+              EOF
+} 

--- a/stock_project/outputs.tf
+++ b/stock_project/outputs.tf
@@ -1,0 +1,25 @@
+# outputs.tf
+
+# EC2 인스턴스 이름 출력
+output "ec2_instance_name" {
+  description = "The name of the EC2 instance"
+  value       = aws_instance.my_ec2_instance.tags["Name"]
+}
+
+# VPC ID 출력
+output "vpc_id" {
+  description = "The VPC ID"
+  value       = var.vpc_id
+}
+
+# Public Subnet ID 출력
+output "public_subnet_id" {
+  description = "The public subnet ID"
+  value       = var.public_subnet_id
+}
+
+# Security Group ID 출력
+output "security_group_id" {
+  description = "The security group ID"
+  value       = aws_security_group.ec2_security_group.id
+}

--- a/stock_project/provider.tf
+++ b/stock_project/provider.tf
@@ -1,0 +1,6 @@
+# provider.tf
+
+provider "aws" {
+    profile = "stocks_sy"
+    region = var.region  # 한국 리전 사용
+}

--- a/stock_project/terraform.tfvars
+++ b/stock_project/terraform.tfvars
@@ -1,0 +1,6 @@
+# terraform.tfvars
+
+azs = ["ap-northeast-2a"]
+ami_id = "ami-05d2438ca66594916" #ubuntu
+vpc_id = "vpc-00399119ce58dac27"
+public_subnet_id = "subnet-0ae18c84d16c48aa9" 

--- a/stock_project/variables.tf
+++ b/stock_project/variables.tf
@@ -1,0 +1,29 @@
+# variables.tf
+
+variable "region" {
+  description = "The AWS region to deploy resources"
+  type        = string
+  default     = "ap-northeast-2"  # 서울 리전 코드
+}
+
+variable "azs" {
+  description = "The availability zones to use for the VPC"
+  type        = list(string)
+}
+
+variable "ami_id" {
+  description = "The AMI ID to use for the EC2 instance"
+}
+
+variable "instance_type" {
+  description = "The EC2 instance type"
+  default     = "t2.micro"
+}
+
+variable "vpc_id" {
+  description = "ID of the existing VPC"
+}
+
+variable "public_subnet_id" {
+  description = "ID of the public subnet for the EC2 instance"
+}


### PR DESCRIPTION
## 개요

> 미리 생성한 VPC, Subnet을 사용해 EC2 생성. 이때 EC2 Security Group은 미리 생성되어 있지 않으므로 module 활용해 생성

## 1. provider.tf

- AWS profile 설정
- region 설정
  - variables.tf에 설정한 값으로 설정 

## 2. main.tf

- EC2 Security Group 생성
  - module 사용
    - Inbound 
      - 22 port 
        - EC2 Instance Connect 사용 예정
      - 80 port
      - 443 port
- EC2 생성
  -  ami, instance_type, vpc, subnet은 variables.tf에 작성한 값으로 설정
  - security group은 위에서 생성한 sg 사용
  - user_data 스크립트
    - public IP로 확인하기 위해 NGINX 설치
  - public IP 활성화
    - 접속 확인 목적 

## 3. variables.tf

- region, azs, ami_id, instance_type
- vpc_id, public_subnet_id

## 4. terraform.tfvars

- azs
  - ap-northeast-2a 
- ami_id
  -  t2.micro 사용
- vpc_id
  - 이전에 생성해둔 VPC Id 삽입 
- public_subnet_id
  - 이전에 생성한 Subnet Id 삽입

## 5.  outputs.tf

- 생성한 리소스(EC2, Security Group)와 기본 VPC, Subnet 출력

## terraform 명령어

```
terraform init
terraform plan
terraform apply
terraform destroy
```

## 결과

outputs.tf 데이터 정상 출력
EC2 Instance Connect로 정상적으로 접근 가능
