### PR TITLE
[Stock Project] EKS 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # gcp-credentials.json git ignore
 *.json
+stock_project_deploy/variables.tf

--- a/stock_project_deploy/eks.tf
+++ b/stock_project_deploy/eks.tf
@@ -1,0 +1,60 @@
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "20.8.5"
+
+  cluster_name    = "sy-cluster"
+  cluster_version = "1.31"
+
+  cluster_endpoint_public_access           = true
+  enable_cluster_creator_admin_permissions = true
+
+  cluster_addons = {
+    aws-ebs-csi-driver = {
+      service_account_role_arn = module.irsa-ebs-csi.iam_role_arn
+    }
+  }
+
+  vpc_id     = "${var.default_vpc}"
+  subnet_ids = "${var.public_subnets}"
+
+  eks_managed_node_group_defaults = {
+    ami_type = "AL2_x86_64"
+  }
+
+  eks_managed_node_groups = {
+    one = {
+      name = "sy-node-group-1"
+
+      instance_types = ["t3.small"]
+
+      min_size     = 1
+      max_size     = 3
+      desired_size = 2
+    }
+
+    two = {
+      name = "sy-node-group-2"
+
+      instance_types = ["t3.small"]
+
+      min_size     = 1
+      max_size     = 2
+      desired_size = 1
+    }
+  }
+}
+
+data "aws_iam_policy" "ebs_csi_policy" {
+  arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+
+module "irsa-ebs-csi" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "5.39.0"
+
+  create_role                   = true
+  role_name                     = "AmazonEKSTFEBSCSIRole-${module.eks.cluster_name}"
+  provider_url                  = module.eks.oidc_provider
+  role_policy_arns              = [data.aws_iam_policy.ebs_csi_policy.arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
+}

--- a/stock_project_deploy/provider.tf
+++ b/stock_project_deploy/provider.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+    profile = "stocks_sy"
+    region = "${var.region}" 
+    access_key = "${var.access_key}"
+    secret_key = "${var.secret_key}"
+}
+data "aws_availability_zones" "azs" {
+  state = "available"
+}


### PR DESCRIPTION
## 개요

> VPC와 Subnet은 생성하지 않고 미리 존재하는 리소스 사용
> Route53, ACM, RDS도 생성하지 않고 콘솔로 생성. 매번 생성하고 삭제할 필요 없음

## 1. eks.tf

- cluster 이름 설정
- EBS CSI Driver 설정
- VPC, Subnet ID를 variables.tf에서 가져옴
- k8s node AMI, 인스턴스 타입, 개수 결정
- EBS CSI를 위한 IRSA 설정

## 2. provider.tf

- profile, 배포할 region 설정
- AWS Access Key와 Secret Key variables.tf에서 할당

## 3. variables.tf

- 🔥 git ignore 처리해 수동으로 파일 추가해야함

```
## AWS
variable "access_key" {
  default = ""
}
variable "secret_key" {
  default = ""
}

variable "base_url" {
  default = "https://openapi.koreainvestment.com:9443"
}

## 오사카
variable "region" {
    default = "ap-northeast-3"
}

## [Secret] 한국투자증권
variable "app_key" {
  default = ""
}
variable "app_secret" {
  default = ""
}

## [Secret] RDS
variable "rds_username" {
  default = ""
}
variable "rds_password" {
  default = ""
}

## 기본 vpc
variable "default_vpc" {
  default = ""
}

variable "private_subnets" {
  default = ["", ""]
}

variable "public_subnets" {
  default = ["", "", ""]
}
```



## terraform 명령어

```
terraform init
terraform apply

# 🔥 EKS 리소스 정리(kubectl delete all --all) 후 terraform destory 진행
terraform destroy
```

## 결과

1. 정상적으로 리소스 생성

  <img width="1166" alt="image" src="https://github.com/user-attachments/assets/30e4faad-873b-4909-8754-14c0e8c53033" />


2. 정상적으로 EKS 생성 후 접속 가능

  EKS 접속 명령어

  ```
  export AWS_PROFILE=stocks_sy
  aws eks --region ap-northeast-3 update-kubeconfig --name sy-EKS-Cluster
  ```
